### PR TITLE
Added 15 Missing Anime Speed Spells Scripts

### DIFF
--- a/script/c513000145.lua
+++ b/script/c513000145.lua
@@ -1,0 +1,33 @@
+--Speed Spell - Angel Baton (Anime)
+--Ｓｐ－エンジェル・バトン
+--scripted by Larry126
+function c513000145.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DRAW+CATEGORY_HANDES)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(c513000145.con)
+	e1:SetTarget(c513000145.target)
+	e1:SetOperation(c513000145.activate)
+	c:RegisterEffect(e1)
+end
+function c513000145.con(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFieldCard(e:GetHandler():GetControler(),LOCATION_SZONE,5)
+	return tc and tc:GetCounter(0x91)>1
+end
+function c513000145.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsPlayerCanDraw(tp,2) end
+	Duel.SetTargetPlayer(tp)
+	Duel.SetTargetParam(2)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,2)
+	Duel.SetOperationInfo(0,CATEGORY_HANDES,nil,0,tp,1)
+end
+function c513000145.activate(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	if Duel.Draw(p,d,REASON_EFFECT)==2 then
+		Duel.BreakEffect()
+		Duel.DiscardHand(tp,aux.TRUE,1,1,REASON_EFFECT)
+	end
+end

--- a/script/c513000146.lua
+++ b/script/c513000146.lua
@@ -1,0 +1,67 @@
+--Speed Spell - Curse of Destiny
+--scripted by Larry126
+function c513000146.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_COUNTER)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCondition(c513000146.con)
+	e1:SetTarget(c513000146.target)
+	e1:SetOperation(c513000146.activate)
+	c:RegisterEffect(e1)
+end
+function c513000146.con(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFieldCard(e:GetHandler():GetControler(),LOCATION_SZONE,5)
+	return tc and tc:GetCounter(0x91)>1
+end
+function c513000146.filter(c)
+	return c:IsFaceup() and c:IsType(TYPE_MONSTER)
+end
+function c513000146.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c513000146.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c513000146.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	Duel.SelectTarget(tp,c513000146.filter,tp,LOCATION_MZONE,0,1,1,nil)
+end
+function c513000146.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
+		tc:AddCounter(0x1042,2)
+		--damage
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetDescription(aux.Stringid(513000146,1))
+		e1:SetCategory(CATEGORY_DAMAGE)
+		e1:SetType(EFFECT_TYPE_IGNITION)
+		e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+		e1:SetRange(LOCATION_MZONE)
+		e1:SetCountLimit(1)
+		e1:SetCost(c513000146.damcost)
+		e1:SetTarget(c513000146.damtg)
+		e1:SetOperation(c513000146.damop)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		tc:RegisterEffect(e1,true)
+	end
+end
+function c513000146.damcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsCanRemoveCounter(tp,0x1042,1,REASON_COST) end
+	e:GetHandler():RemoveCounter(tp,0x1042,1,REASON_COST)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_OATH)
+	e1:SetCode(EFFECT_CANNOT_ATTACK_ANNOUNCE)
+	e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+	e:GetHandler():RegisterEffect(e1)
+end
+function c513000146.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	local dam=e:GetHandler():GetAttack()/2
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetTargetParam(dam)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,0,0,1-tp,dam)
+end
+function c513000146.damop(e,tp,eg,ep,ev,re,r,rp)
+	local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)
+	Duel.Damage(p,e:GetHandler():GetAttack()/2,REASON_EFFECT)
+end

--- a/script/c513000147.lua
+++ b/script/c513000147.lua
@@ -1,0 +1,32 @@
+--Speed Spell - The End of the Storm (Anime)
+--Ｓｐ－ジ・エンド・オブ・ストーム
+--scripted by Larry126
+function c513000147.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DESTROY+CATEGORY_DAMAGE)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCost(c513000147.con)
+	e1:SetTarget(c513000147.target)
+	e1:SetOperation(c513000147.activate)
+	c:RegisterEffect(e1)
+end
+function c513000147.con(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFieldCard(e:GetHandler():GetControler(),LOCATION_SZONE,5)
+	return tc and tc:GetCounter(0x91)>9
+end
+function c513000147.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsDestructable,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	local g=Duel.GetMatchingGroup(Card.IsDestructable,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,0,g:GetCount()*300)
+end
+function c513000147.activate(e,tp,eg,ep,ev,re,r,rp)
+	local g1=Duel.GetMatchingGroup(Card.IsDestructable,tp,LOCATION_MZONE,0,nil)
+	local g2=Duel.GetMatchingGroup(Card.IsDestructable,tp,0,LOCATION_MZONE,nil)
+	local ct1=Duel.Destroy(g1,REASON_EFFECT)
+	local ct2=Duel.Destroy(g2,REASON_EFFECT)
+	Duel.Damage(tp,ct1*300,REASON_EFFECT)
+	Duel.Damage(1-tp,ct2*300,REASON_EFFECT)
+end

--- a/script/c513000148.lua
+++ b/script/c513000148.lua
@@ -1,0 +1,53 @@
+--Speed Spell - Final Attack (Anime)
+--Ｓｐ－ファイナル・アタック
+--scripted by Larry126
+function c513000148.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_ATKCHANGE)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(c513000148.con)
+	e1:SetTarget(c513000148.target)
+	e1:SetOperation(c513000148.activate)
+	c:RegisterEffect(e1)
+end
+function c513000148.con(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFieldCard(e:GetHandler():GetControler(),LOCATION_SZONE,5)
+	return tc and tc:GetCounter(0x91)>7
+end
+function c513000148.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and chkc:IsFaceup() end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil) end
+	return true
+end
+function c513000148.activate(e,tp,eg,ep,ev,re,r,rp)
+	local dg=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,0,nil)	
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	local tdg=dg:Select(tp,1,1,nil)
+	local tc=tdg:GetFirst() 
+	if tc:IsFaceup() then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_SET_ATTACK)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		e1:SetValue(tc:GetBaseAttack()*2)
+		tc:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(e:GetHandler())
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_CANNOT_DIRECT_ATTACK)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		tc:RegisterEffect(e2)
+		local e3=Effect.CreateEffect(e:GetHandler())
+		e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e3:SetRange(LOCATION_MZONE)
+		e3:SetCode(EVENT_PHASE+PHASE_END)
+		e3:SetOperation(c513000148.desop)
+		e3:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		e3:SetCountLimit(1)
+		tc:RegisterEffect(e3)
+	end
+end
+function c513000148.desop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Destroy(e:GetHandler(),REASON_EFFECT)
+end

--- a/script/c513000149.lua
+++ b/script/c513000149.lua
@@ -1,0 +1,45 @@
+--Speed Spell - Deceased Synchron (Anime)
+--scripted by Larry126
+function c513000149.initial_effect(c)
+	--synchro effect
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(c513000149.con)
+	e1:SetTarget(c513000149.sctg)
+	e1:SetOperation(c513000149.scop)
+	c:RegisterEffect(e1)
+end
+function c513000149.con(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFieldCard(e:GetHandler():GetControler(),LOCATION_SZONE,5)
+	return tc and tc:GetCounter(0x91)>4
+end
+function c513000149.sctg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local mg=Duel.GetMatchingGroup(Card.IsCanBeSynchroMaterial,tp,LOCATION_GRAVE,0,nil)
+	if chkc then return chkc:IsLocation(LOCATION_EXTRA) and chkc:IsSynchroSummonable(nil,mg) end
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsSynchroSummonable,tp,LOCATION_EXTRA,0,1,nil,nil,mg) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,Card.IsSynchroSummonable,tp,LOCATION_EXTRA,0,1,1,nil,nil,mg)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g:GetFirst(),1,tp,LOCATION_EXTRA)
+end
+function c513000149.scop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	local mg=Duel.GetMatchingGroup(Card.IsCanBeSynchroMaterial,tp,LOCATION_GRAVE,0,nil)
+	Auxiliary.SynchroSend=2   
+	if Duel.SynchroSummon(tp,tc,nil,mg) then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e1:SetRange(LOCATION_MZONE)
+		e1:SetCode(EVENT_PHASE+PHASE_END)
+		e1:SetOperation(c513000149.desop)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		e1:SetCountLimit(1)
+		tc:RegisterEffect(e1)
+	end
+	Auxiliary.SynchroSend=0
+end
+function c513000149.desop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+end

--- a/script/c513000150.lua
+++ b/script/c513000150.lua
@@ -1,0 +1,38 @@
+--Speed Spell - Half Seize (Anime)
+--Ｓｐ－ハーフ・シーズ
+--scripted by Larry126
+function c513000150.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_ATKCHANGE+CATEGORY_RECOVER)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(c513000150.con)
+	e1:SetTarget(c513000150.target)
+	e1:SetOperation(c513000150.operation)
+	c:RegisterEffect(e1)
+end
+function c513000150.con(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFieldCard(e:GetHandler():GetControler(),LOCATION_SZONE,5)
+	return tc and tc:GetCounter(0x91)>2
+end
+function c513000150.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_RECOVER,nil,0,tp,0)
+end
+function c513000150.operation(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	local g=Duel.SelectMatchingCard(tp,Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.HintSelection(g)
+		local atk=g:GetFirst():GetAttack()/2
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_SET_ATTACK_FINAL)
+		e1:SetValue(atk)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		if g:GetFirst():RegisterEffect(e1) then
+			Duel.Recover(tp,atk,REASON_EFFECT)
+		end
+	end
+end

--- a/script/c513000151.lua
+++ b/script/c513000151.lua
@@ -1,0 +1,39 @@
+--Speed Spell - High Speed Crash (Anime)
+--Ｓｐ－ハイスピード・クラッシュ
+--scritped by Larry126
+function c513000151.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DESTROY)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(c513000151.con)
+	e1:SetTarget(c513000151.target)
+	e1:SetOperation(c513000151.operation)
+	c:RegisterEffect(e1)
+end
+function c513000151.con(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFieldCard(e:GetHandler():GetControler(),LOCATION_SZONE,5)
+	return tc and tc:GetCounter(0x91)>1
+end
+function c513000151.filter(c,card)
+	return c:IsDestructable() and Duel.IsExistingTarget(c513000151.filter2,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,c,card)
+end
+function c513000151.filter2(c,card)
+	return c:IsDestructable() and c~=card
+end
+function c513000151.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local c=e:GetHandler()
+	if chkc then return false end
+	if chk==0 then return Duel.IsExistingTarget(c513000151.filter,tp,LOCATION_ONFIELD,0,1,c,c) end  
+	local g=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,2,0,0)
+end
+function c513000151.operation(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g1=Duel.SelectMatchingCard(tp,c513000151.filter,tp,LOCATION_ONFIELD,0,1,1,c,c)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g2=Duel.SelectMatchingCard(tp,c513000151.filter2,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,g1:GetFirst(),c)
+	g1:Merge(g2)
+	Duel.Destroy(g1,REASON_EFFECT)
+end

--- a/script/c513000152.lua
+++ b/script/c513000152.lua
@@ -1,0 +1,46 @@
+--Speed Spell - Silver Contrails (Anime)
+--Ｓｐ－シルバー・コントレイル
+--scripted by Larry126
+function c513000152.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_ATKCHANGE)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
+	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(c513000152.con)
+	e1:SetTarget(c513000152.target)
+	e1:SetOperation(c513000152.activate)
+	c:RegisterEffect(e1)
+end
+function c513000152.con(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFieldCard(e:GetHandler():GetControler(),LOCATION_SZONE,5)
+	return tc and tc:GetCounter(0x91)>4
+end
+function c513000152.filter(c)
+	return c:IsFaceup() and c:IsAttackable(ATTRIBUTE_WIND)
+end
+function c513000152.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and chkc:IsFaceup() end
+	if chk==0 then return Duel.IsExistingTarget(c513000152.filter,tp,LOCATION_MZONE,0,1,nil) end
+	return true
+end
+function c513000152.activate(e,tp,eg,ep,ev,re,r,rp)
+	local dg=Duel.GetMatchingGroup(c513000152.filter,tp,LOCATION_MZONE,0,nil)	  
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	local tdg=dg:Select(tp,1,1,nil)
+	local tc=tdg:GetFirst() 
+	if tc:IsFaceup() then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetCondition(c513000152.atkcon)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		e1:SetValue(1000)
+		tc:RegisterEffect(e1)
+	end
+end
+function c513000152.atkcon(e)
+	return bit.band(Duel.GetCurrentPhase(),0x38)~=0
+end

--- a/script/c513000153.lua
+++ b/script/c513000153.lua
@@ -1,0 +1,34 @@
+--Speed Spell - Sonic Buster (Anime)
+--Ｓｐ－ソニック・バスター
+--scripted by Larry126
+function c513000153.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DAMAGE)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(c513000153.con)
+	e1:SetTarget(c513000153.target)
+	e1:SetOperation(c513000153.activate)
+	c:RegisterEffect(e1)
+end
+function c513000153.con(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFieldCard(e:GetHandler():GetControler(),LOCATION_SZONE,5)
+	return tc and tc:GetCounter(0x91)>3
+end
+function c513000153.filter(c,tp)
+	local atk=c:GetAttack()/2
+	return c:IsFaceup() and Duel.GetLP(1-tp)>atk
+end
+function c513000153.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c513000153.filter,tp,LOCATION_MZONE,0,1,nil,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,0)
+end
+function c513000153.activate(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	local tc=Duel.SelectMatchingCard(tp,c513000153.filter,tp,LOCATION_MZONE,0,1,1,nil,tp):GetFirst()
+	if tc and tc:IsFaceup() then
+		Duel.Damage(1-tp,tc:GetAttack()/2,REASON_EFFECT)
+	end
+end

--- a/script/c513000154.lua
+++ b/script/c513000154.lua
@@ -1,0 +1,40 @@
+--Speed Spell - Speed Energy (Anime)
+--Ｓｐ−スピード・エナジー
+--scripted by Larry126
+function c513000154.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_ATKCHANGE)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
+	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(c513000154.con)
+	e1:SetTarget(c513000154.target)
+	e1:SetOperation(c513000154.activate)
+	c:RegisterEffect(e1)
+end
+function c513000154.con(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFieldCard(e:GetHandler():GetControler(),LOCATION_SZONE,5)
+	return tc and tc:GetCounter(0x91)>1
+end
+function c513000154.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and chkc:IsFaceup() end
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil) end
+	return true
+end
+function c513000154.activate(e,tp,eg,ep,ev,re,r,rp)
+	local dg=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,0,nil)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	local tdg=dg:Select(tp,1,1,nil)
+	local tc=tdg:GetFirst() 
+	local td=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+	if tc:IsFaceup() then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		e1:SetValue(td:GetCounter(0x91)*200)
+		tc:RegisterEffect(e1)
+	end
+end

--- a/script/c513000155.lua
+++ b/script/c513000155.lua
@@ -1,0 +1,30 @@
+--Speed Spell - Speed Force (Anime)
+--Ｓｐ－スピード・フォース
+--scripted by Larry126
+function c513000155.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(c513000155.con)
+	e1:SetOperation(c513000155.activate)
+	c:RegisterEffect(e1)
+end
+function c513000155.con(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+	return tc and tc:GetCounter(0x91)>3
+end
+function c513000155.activate(e,tp,eg,ep,ev,re,r,rp)
+	--indestructable
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)
+	e1:SetTargetRange(LOCATION_ONFIELD,0)
+	e1:SetProperty(EFFECT_FLAG_SET_AVAILABLE)
+	e1:SetValue(c513000155.indval)
+	e1:SetReset(RESET_PHASE+PHASE_END+RESET_SELF_TURN,2)
+	Duel.RegisterEffect(e1,tp)
+end
+function c513000155.indval(e,re,rp)
+	return re:IsActiveType(TYPE_SPELL+TYPE_TRAP) and re:GetOwner()~=e:GetOwner()
+end

--- a/script/c513000156.lua
+++ b/script/c513000156.lua
@@ -1,0 +1,43 @@
+--Speed Spell - Summon Close (Anime)
+--Ｓｐ－サモンクローズ
+--scripted by Larry126
+function c513000156.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DRAW)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCost(c513000156.cost)
+	e1:SetCondition(c513000156.con)
+	e1:SetTarget(c513000156.target)
+	e1:SetOperation(c513000156.activate)
+	c:RegisterEffect(e1)
+end
+function c513000156.con(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFieldCard(e:GetHandler():GetControler(),LOCATION_SZONE,5)
+	return tc and tc:GetCounter(0x91)>3
+end
+function c513000156.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToGraveAsCost,tp,LOCATION_HAND,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=Duel.SelectMatchingCard(tp,Card.IsAbleToGraveAsCost,tp,LOCATION_HAND,0,1,1,nil)
+	Duel.SendtoGrave(g,REASON_COST)
+end
+function c513000156.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsPlayerCanDraw(tp,1) end
+	Duel.SetTargetPlayer(tp)
+	Duel.SetTargetParam(1)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
+end
+function c513000156.activate(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Draw(p,d,REASON_EFFECT)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetTargetRange(0,1)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,p)
+end

--- a/script/c513000157.lua
+++ b/script/c513000157.lua
@@ -1,0 +1,47 @@
+--Speed Spell - Tyrant Force (Anime)
+--scripted by Larry126
+function c513000157.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(c513000157.con)
+	e1:SetOperation(c513000157.activate)
+	c:RegisterEffect(e1)
+end
+function c513000157.con(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFieldCard(e:GetHandler():GetControler(),LOCATION_SZONE,5)
+	return tc and tc:GetCounter(0x91)>9
+end
+function c513000157.activate(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE+EFFECT_FLAG_SET_AVAILABLE)
+	e1:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
+	e1:SetTargetRange(LOCATION_ONFIELD,0)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	e1:SetValue(1)
+	Duel.RegisterEffect(e1,tp)
+	local e2=e1:Clone()
+	e2:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)
+	Duel.RegisterEffect(e2,tp)
+	--Activate
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e3:SetCode(EVENT_DESTROYED)
+	e3:SetCondition(c513000157.damcon)
+	e3:SetOperation(c513000157.damop)
+	e3:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e3,tp)
+end
+function c513000157.cfilter(c,tp)
+	return c:GetPreviousControler()==1-tp
+end
+function c513000157.damcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(c513000157.cfilter,1,nil,tp)
+end
+function c513000157.damop(e,tp,eg,ep,ev,re,r,rp)
+	local ct=eg:FilterCount(c513000157.cfilter,nil,tp)
+	Duel.Damage(1-tp,ct*300,REASON_EFFECT)
+end

--- a/script/c513000158.lua
+++ b/script/c513000158.lua
@@ -1,0 +1,48 @@
+--Speed Spell - Vision Wind (Anime)
+--Ｓｐ－ヴィジョンウィンド
+--scripted by Larry126
+function c513000158.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(c513000158.con)
+	e1:SetTarget(c513000158.target)
+	e1:SetOperation(c513000158.activate)
+	c:RegisterEffect(e1)
+end
+function c513000158.con(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+	return tc and tc:GetCounter(0x91)>1
+end
+function c513000158.filter(c,e,tp)
+	return c:IsLevelBelow(2) and c:IsType(TYPE_MONSTER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c513000158.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c513000158.filter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c513000158.filter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	return true
+end
+function c513000158.activate(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	local c=e:GetHandler()
+	local dg=Duel.GetMatchingGroup(c513000158.filter,c:GetControler(),LOCATION_GRAVE,0,nil,e,tp)	
+	Duel.Hint(HINT_SELECTMSG,c:GetControler(),HINTMSG_SPSUMMON)
+	local tc=dg:Select(c:GetControler(),1,1,nil):GetFirst()
+	if tc and Duel.SpecialSummonStep(tc,0,tp,tp,false,false,POS_FACEUP) then
+		local e3=Effect.CreateEffect(c)
+		e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e3:SetRange(LOCATION_MZONE)
+		e3:SetCode(EVENT_PHASE+PHASE_END)
+		e3:SetOperation(c513000158.desop)
+		e3:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		e3:SetCountLimit(1)
+		tc:RegisterEffect(e3)
+		Duel.SpecialSummonComplete()
+	end
+end
+function c513000158.desop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Destroy(e:GetHandler(),REASON_EFFECT)
+end

--- a/script/c513000159.lua
+++ b/script/c513000159.lua
@@ -1,0 +1,44 @@
+--Speed Spell - Zero Reverse (Anime)
+--Ｓｐ−ゼロ・リバース
+--scripted by Larry126
+function c513000159.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(c513000159.con)
+	e1:SetTarget(c513000159.target)
+	e1:SetOperation(c513000159.activate)
+	c:RegisterEffect(e1)
+end
+function c513000159.con(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+	return tc and tc:GetCounter(0x91)>2
+end
+function c513000159.filter(c,id,e,tp)
+	return c:IsReason(REASON_DESTROY) and c:IsReason(REASON_EFFECT) and c:GetTurnID()==id and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c513000159.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0 
+		and Duel.IsExistingMatchingCard(c513000159.filter,tp,LOCATION_GRAVE,0,1,nil,Duel.GetTurnCount(),e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_GRAVE)
+end
+function c513000159.activate(e,tp,eg,ep,ev,re,r,rp)
+	local ft1=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	if ft1==0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c513000159.filter,tp,LOCATION_GRAVE,0,1,1,nil,Duel.GetTurnCount(),e,tp)
+	local tc=g:GetFirst()
+	local td=tp
+	if tc:GetPreviousControler()~=tp then td=1-tp end
+	if Duel.SpecialSummonStep(tc,0,tp,td,false,false,POS_FACEUP_ATTACK) then 
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_SET_ATTACK_FINAL)
+		e1:SetValue(0)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		tc:RegisterEffect(e1)
+		Duel.SpecialSummonComplete()
+	end
+end


### PR DESCRIPTION
Speed Spell - Angel Baton
Speed Spell - Curse of Destiny
Speed Spell - End of the Storm
Speed Spell - Final Attack
Speed Spell - Fallen Synchron
Speed Spell - Half Seize
Speed Spell - High Speed Crash
Speed Spell - Silver Contrails
Speed Spell - Sonic Buster test
Speed Spell - Speed Energy
Speed Spell - Speed Force
Speed Spell - Summon Close
Speed Spell - Tyrant Force
Speed Spell - Vision Wind
Speed Spell - Zero Reverse